### PR TITLE
Bind eth0 connection to eth0 device (resolves #24).

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -49,4 +49,7 @@ echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh
 
+# Bind the eth0 connection to the eth0 device (#24)
+nmcli connection modify eth0 connection.interface-name eth0
+
 %end


### PR DESCRIPTION
This resolves the issue for me, but I don't know whether this is the best solution.  It would break an environment did not have an eth0 device, though I don't believe such an environment ever exists in Vagrant.