### PR TITLE
include bzip2 in the base image

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -30,6 +30,7 @@ reboot
 deltarpm
 bash-completion
 man-pages
+bzip2
 @core
 
 %end


### PR DESCRIPTION
related the following:

* https://github.com/CentOS/sig-cloud-instance-build/issues/27
* https://github.com/dotless-de/vagrant-vbguest/issues/167