### PR TITLE
Change default Vagrant synced folder to "/vagrant".

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,8 +1,10 @@
-Notes:
+Notes
+-----
 
-In order to disable the rsync option in your Vagrantfile, you need to use this snippet:
+To disable the default Vagrant synced folder (`/vagrant`), you need to add the
+following snippet to your `Vagrantfile`:
 
 ~~~ruby
-config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
+config.vm.synced_folder ".", "/vagrant", disabled: true
 ~~~
 

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -30,7 +30,7 @@ build_vagrant_image()
     --format=rhevm-ova \
     --ova-option vsphere_ova_format=vagrant-virtualbox \
     --ova-option rhevm_ova_format=vagrant-libvirt \
-    --ova-option vagrant_sync_directory=/home/vagrant/sync \
+    --ova-option vagrant_sync_directory=/vagrant \
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\
     --scratch \


### PR DESCRIPTION
This is the expected default for Vagrant boxes:
https://docs.vagrantup.com/v2/synced-folders/

Note that the current default synced folder location caused confusion for many people (including me): mitchellh/vagrant#6154.