### PR TITLE
Adding no_timer_check to the bootloader

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc America/New_York
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 


### PR DESCRIPTION
As timer check should be disabled by-default with
hypervisors

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>