### PR TITLE
Add support for building Vagrant images for CentOS 6

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -1,0 +1,64 @@
+#repo http://mirror.centos.org/centos/6/os/x86_64/
+install
+text
+keyboard us
+lang en_US.UTF-8
+skipx
+network --device eth0 --bootproto dhcp
+rootpw %ROOTPW%
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc America/New_York
+# The biosdevname and ifnames options ensure we get "eth0" as our interface
+# even in environments like virtualbox that emulate a real NW card
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+zerombr
+clearpart --all --drives=vda
+
+user --name=vagrant --password=vagrant
+
+part biosboot --fstype=biosboot --size=1
+part /boot --fstype ext4 --size=200 --ondisk=vda
+part pv.2 --size=1 --grow --ondisk=vda
+volgroup VolGroup00 --pesize=32768 pv.2
+logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
+logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
+reboot
+
+%packages
+deltarpm
+man-pages
+bzip2
+@core
+rsync
+screen
+nfs-utils
+
+%end
+
+%post
+
+# sudo
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+# Fix for https://github.com/CentOS/sig-cloud-instance-build/issues/38
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+
+# Default insecure vagrant key
+mkdir -m 0700 -p /home/vagrant/.ssh
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+# Workaround for SSH pubkey auth not working, due to .ssh having the
+# wrong SELinux context (see "Known Issues" in the CentOS 6 release notes)
+restorecon -vR /home/vagrant/.ssh
+
+%end

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -1,22 +1,61 @@
 #!/bin/sh
 #To see all options in koji -p command check "koji -p cbs image-build --help"
+set -eu
 
-koji -p cbs image-build \
-  centos-7 1  bananas7-el7 \
-  http://mirror.centos.org/centos/7/os/x86_64/ x86_64 \
-  --release=1 \
-  --distro RHEL-7.0 \
-  --ksver RHEL7 \
-  --kickstart=./centos7.ks \
-  --format=qcow2 \
-  --format=vsphere-ova \
-  --format=rhevm-ova \
-  --ova-option vsphere_ova_format=vagrant-virtualbox \
-  --ova-option rhevm_ova_format=vagrant-libvirt \
-  --ova-option vagrant_sync_directory=/home/vagrant/sync \
-  --repo http://mirror.centos.org/centos/7/extras/x86_64/\
-  --repo http://mirror.centos.org/centos/7/updates/x86_64/\
-  --scratch \
-  --nowait \
-  --disk-size=40
+usage()
+{
+  cat << EOF
+usage: $(basename $0) <argument>
+  where <argument> is one of:
+    6   -- build Vagrant images for CentOS 6
+    7   -- build Vagrant images for CentOS 7
+    all -- build Vagrant images for both CentOS 6 and 7
+EOF
+  exit 1
+}
+
+
+build_vagrant_image()
+{
+  EL_MAJOR=$1
+  koji -p cbs image-build \
+    centos-${EL_MAJOR} 1  bananas${EL_MAJOR}-el${EL_MAJOR} \
+    http://mirror.centos.org/centos/${EL_MAJOR}/os/x86_64/ x86_64 \
+    --release=1 \
+    --distro RHEL-${EL_MAJOR}.0 \
+    --ksver RHEL${EL_MAJOR} \
+    --kickstart=./centos${EL_MAJOR}.ks \
+    --format=qcow2 \
+    --format=vsphere-ova \
+    --format=rhevm-ova \
+    --ova-option vsphere_ova_format=vagrant-virtualbox \
+    --ova-option rhevm_ova_format=vagrant-libvirt \
+    --ova-option vagrant_sync_directory=/home/vagrant/sync \
+    --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
+    --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\
+    --scratch \
+    --nowait \
+    --disk-size=40
+}
+
+
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+case $1 in
+  6)
+    build_vagrant_image 6
+    ;;
+  7)
+    build_vagrant_image 7
+    ;;
+  all)
+    build_vagrant_image 6
+    build_vagrant_image 7
+    ;;
+  *)
+    usage
+    ;;
+esac
 


### PR DESCRIPTION
Added support for building CentOS 6 images, in addition to CentOS 7. Pass "6", "7" or "all" to the build script in the vagrant directory. I already tested the images produced by the new version (both 6 and 7) - everything works as expected.