### PR TITLE
let systemd set a new machine-id, set yum vars to point at CentOS7 

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -59,4 +59,8 @@ echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh
 
+# let systemd set a new machine-id
+rm /etc/machine-id
+echo 'vag7' > /etc/yum/vars/infra
+
 %end


### PR DESCRIPTION
All our vagrant machines run with the same machine-id, this would allow systemd to regen a new one the first time vagrant up is run.

additionally, point yum infra to indicate vagrant7 infra is being used.