### PR TITLE
Increase the size of the /boot partition to the recommended value

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -19,7 +19,7 @@ clearpart --all --drives=vda
 user --name=vagrant --password=vagrant
 
 part biosboot --fstype=biosboot --size=1
-part /boot --fstype ext4 --size=200 --ondisk=vda
+part /boot --fstype ext4 --size=250 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -19,7 +19,7 @@ clearpart --all --drives=vda
 user --name=vagrant --password=vagrant
 
 part biosboot --fstype=biosboot --size=1
-part /boot --fstype ext4 --size=200 --ondisk=vda
+part /boot --fstype ext4 --size=500 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536


### PR DESCRIPTION
We had at least one user complaining that it becomes impossible to perform upgrades in VMs due to insufficient space in /boot. According to the upstream Installation Guides, the recommended sizes for the /boot partition are 250MB for CentOS 6 and 500MB for CentOS 7:

[https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html-single/Installation_Guide/#s2-diskpartrecommend-x86](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html-single/Installation_Guide/#s2-diskpartrecommend-x86)

[https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-disk-partitioning-setup-x86.html#sect-recommended-partitioning-scheme-x86](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-disk-partitioning-setup-x86.html#sect-recommended-partitioning-scheme-x86)
