### PR TITLE
Do not install deltarpm by default in CentOS 6

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -27,7 +27,6 @@ logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages
-deltarpm
 man-pages
 bzip2
 @core


### PR DESCRIPTION
Deltarpm reduces the data usage by allowing yum to only download
binary diffs against the packages you already have installed. This
is slower than just downloading the full packages over a broadband
connection, and generates high CPU and I/O load while it rebuilds
the full RPMs locally. This is especially problematic for servers
hosting a large number of guest VMs.