### PR TITLE
Remove duplicate grub packages

### DIFF
--- a/docker/centos-5.11.ks
+++ b/docker/centos-5.11.ks
@@ -18,7 +18,6 @@ vim-minimal
 yum
 bash
 bind-utils
-grub
 centos-release
 shadow-utils
 findutils

--- a/docker/centos-5.ks
+++ b/docker/centos-5.ks
@@ -19,7 +19,6 @@ vim-minimal
 yum
 bash
 bind-utils
-grub
 centos-release
 shadow-utils
 findutils

--- a/docker/centos-6.6.ks
+++ b/docker/centos-6.6.ks
@@ -17,7 +17,6 @@ vim-minimal
 yum
 bash
 bind-utils
-grub
 centos-release
 shadow-utils
 findutils

--- a/docker/centos-6.ks
+++ b/docker/centos-6.ks
@@ -22,7 +22,6 @@ vim-minimal
 yum
 bash
 bind-utils
-grub
 centos-release
 shadow-utils
 findutils


### PR DESCRIPTION
On docker CentOS 5 and 6 kickstart files.