### PR TITLE
Bring Vagrant box setup in line with upstream recommendations

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -54,11 +54,19 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
-# sshd: disable password authentication
+# sshd: disable password authentication and DNS checks
 ex -s /etc/ssh/sshd_config <<-EOF
 	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+	:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
 	:update
 	:quit
+EOF
+cat >>/etc/sysconfig/sshd <<-EOF
+
+	# Decrease connection time by preventing reverse DNS lookups
+	# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+	#  and man sshd for more information)
+	OPTIONS="-u0"
 EOF
 
 # Default insecure vagrant key

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -69,4 +69,7 @@ echo 'vag' > /etc/yum/vars/infra
 # Configure tuned
 tuned-adm profile virtual-guest
 
+# Configure grub to wait just 1 second before booting
+sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
+
 %end

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -54,6 +54,13 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
+# sshd: disable password authentication
+ex -s /etc/ssh/sshd_config <<-EOF
+	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+	:update
+	:quit
+EOF
+
 # Default insecure vagrant key
 mkdir -m 0700 -p /home/vagrant/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -5,7 +5,7 @@ keyboard us
 lang en_US.UTF-8
 skipx
 network --device eth0 --bootproto dhcp
-rootpw %ROOTPW%
+rootpw vagrant
 firewall --disabled
 authconfig --enableshadow --enablemd5
 selinux --enforcing

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -55,6 +55,13 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
+# sshd: disable password authentication
+ex -s /etc/ssh/sshd_config <<-EOF
+	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+	:update
+	:quit
+EOF
+
 # Default insecure vagrant key
 mkdir -m 0700 -p /home/vagrant/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -55,11 +55,19 @@ TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 EOF
 
-# sshd: disable password authentication
+# sshd: disable password authentication and DNS checks
 ex -s /etc/ssh/sshd_config <<-EOF
 	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+	:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
 	:update
 	:quit
+EOF
+cat >>/etc/sysconfig/sshd <<-EOF
+
+	# Decrease connection time by preventing reverse DNS lookups
+	# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+	#  and man sshd for more information)
+	OPTIONS="-u0"
 EOF
 
 # Default insecure vagrant key

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -69,4 +69,7 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 
 echo 'vag' > /etc/yum/vars/infra
 
+# Configure grub to wait just 1 second before booting
+sed -i 's/^GRUB_TIMEOUT=[0-9]\+$/GRUB_TIMEOUT=1/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg
+
 %end

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -5,7 +5,7 @@ keyboard us
 lang en_US.UTF-8
 skipx
 network --device eth0 --bootproto dhcp
-rootpw %ROOTPW%
+rootpw --plaintext vagrant
 firewall --disabled
 authconfig --enableshadow --enablemd5
 selinux --enforcing


### PR DESCRIPTION
* bring the Vagrant box setup in line with the [Vagrant upstream recommendations](https://www.vagrantup.com/docs/boxes/base.html):
  * set the `root` password to `vagrant` (fixes issue #30)
  * disable DNS lookups in `sshd`
* set the GRUB timeout to 1 second, to reduce the time needed by `vagrant up`
* __security__: disable password authentication in `sshd` (Vagrant boxes have publicly known passwords for the `root` and `vagrant` users)