### PR TITLE
Allow do_vagrant_cbs.sh to be invoked from any directory

### DIFF
--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -17,6 +17,8 @@ EOF
 
 build_vagrant_image()
 {
+  # The kickstart files are in the same directory as this script
+  KS_DIR=$(dirname $0)
   EL_MAJOR=$1
   koji -p cbs image-build \
     centos-${EL_MAJOR} 1  bananas${EL_MAJOR}-el${EL_MAJOR} \
@@ -24,7 +26,7 @@ build_vagrant_image()
     --release=1 \
     --distro RHEL-${EL_MAJOR}.0 \
     --ksver RHEL${EL_MAJOR} \
-    --kickstart=./centos${EL_MAJOR}.ks \
+    --kickstart=${KS_DIR}/centos${EL_MAJOR}.ks \
     --format=qcow2 \
     --format=vsphere-ova \
     --format=rhevm-ova \
@@ -38,9 +40,6 @@ build_vagrant_image()
     --disk-size=40
 }
 
-
-# Change the current directory to where this script is placed (issue #60)
-cd $(dirname $(realpath $0))
 
 if [ $# -ne 1 ]; then
   usage

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -39,6 +39,9 @@ build_vagrant_image()
 }
 
 
+# Change the current directory to where this script is placed (issue #60)
+cd $(dirname $(realpath $0))
+
 if [ $# -ne 1 ]; then
   usage
 fi


### PR DESCRIPTION
Fix for issue #60: invoking koji relies on it being able to read the kickstart files for Anaconda from the current directory; changing the current directory to where the do_vagrant_cbs.sh script resides allows it to be called from any directory