### PR TITLE
Generate Vagrant images for the VMware provider

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -87,4 +87,12 @@ tuned-adm profile virtual-guest
 # Configure grub to wait just 1 second before booting
 sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 
+# Enable VMware PVSCSI support for VMware Fusion guests. This produces
+# a tiny increase in the image and is harmless for other environments.
+pushd /etc/dracut.conf.d
+echo 'add_drivers+="mptspi"' > vmware-fusion-drivers.conf
+popd
+# Rerun dracut for the installed kernel (not the running kernel):
+KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
+dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
 %end

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -87,4 +87,13 @@ echo 'vag' > /etc/yum/vars/infra
 # Configure grub to wait just 1 second before booting
 sed -i 's/^GRUB_TIMEOUT=[0-9]\+$/GRUB_TIMEOUT=1/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg
 
+# Enable VMware PVSCSI support for VMware Fusion guests. This produces
+# a tiny increase in the image and is harmless for other environments.
+pushd /etc/dracut.conf.d
+echo 'add_drivers+="mptspi"' > vmware-fusion-drivers.conf
+popd
+# Rerun dracut for the installed kernel (not the running kernel):
+KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
+dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
+
 %end

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -31,11 +31,9 @@ build_vagrant_image()
     --distro RHEL-${EL_MAJOR}.0 \
     --ksver RHEL${EL_MAJOR} \
     --kickstart=${KS_DIR}/centos${EL_MAJOR}.ks \
-    --format=qcow2 \
-    --format=vsphere-ova \
-    --format=rhevm-ova \
-    --ova-option vsphere_ova_format=vagrant-virtualbox \
-    --ova-option rhevm_ova_format=vagrant-libvirt \
+    --format=vagrant-libvirt \
+    --format=vagrant-virtualbox \
+    --format=vagrant-vmware-fusion \
     --ova-option vagrant_sync_directory=/vagrant \
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\


### PR DESCRIPTION
Added support for generating VMware images (the [tests](https://github.com/lpancescu/cloudinstance-vagrant-cico-util) used by ci.centos.org have already been updated; since this PR changes the names of the generated image files, other CI tests will fail until this PR is merged).