### PR TITLE
Add spacing around mptsci module in dracut config

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -90,7 +90,7 @@ sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 # Enable VMware PVSCSI support for VMware Fusion guests. This produces
 # a tiny increase in the image and is harmless for other environments.
 pushd /etc/dracut.conf.d
-echo 'add_drivers+="mptspi"' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
 popd
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -90,7 +90,7 @@ sed -i 's/^GRUB_TIMEOUT=[0-9]\+$/GRUB_TIMEOUT=1/' /etc/default/grub && grub2-mkc
 # Enable VMware PVSCSI support for VMware Fusion guests. This produces
 # a tiny increase in the image and is harmless for other environments.
 pushd /etc/dracut.conf.d
-echo 'add_drivers+="mptspi"' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
 popd
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')


### PR DESCRIPTION
When adding the VMware Tools software to the CentOS 7 vagrant box (required to get synced folders working), the following errors are generated during the vmware-config-tools.pl step:

```
...
Creating a new initrd boot image for the kernel.
/bin/dracut --force --add-drivers "vmxnet3 vmw_pvscsi" 
/boot/initramfs-3.10.0-327.28.3.el7.x86_64.img 3.10.0-327.28.3.el7.x86_64 
>/dev/null 2>&1

Broadcast message from systemd-journald@localhost.localdomain (Tue 2016-09-13 16:57:37 UTC):

dracut[24942]: Failed to install module mptspivmxnet3


Message from syslogd@localhost at Sep 13 16:57:37 ...
 dracut:Failed to install module mptspivmxnet3
...
```

Adding whitespace around the mptspi module in /etc/dracut.conf.d/vmware-fusion-drivers.conf seems to resolve the issue (on CentOS 7 at least, I haven't tested on CentOS 6).