### PR TITLE
Change the default filesystem of centos/7 to XFS

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -19,11 +19,11 @@ clearpart --all --drives=vda
 user --name=vagrant --password=vagrant
 
 part biosboot --fstype=biosboot --size=1
-part /boot --fstype ext4 --size=500 --ondisk=vda
+part /boot --fstype xfs --size=500 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
-logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
+logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages


### PR DESCRIPTION
XFS is the default filesystem for CentOS Linux 7. It has very good
performance  and, unlike Ext4, it allocates inodes dynamically.

Fixes issue #74.