### PR TITLE
Prevent users from using su to become root or vagrant

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -55,18 +55,18 @@ PERSISTENT_DHCLIENT="yes"
 EOF
 
 # sshd: disable password authentication and DNS checks
-ex -s /etc/ssh/sshd_config <<-EOF
-	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
-	:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
-	:update
-	:quit
+ex -s /etc/ssh/sshd_config <<EOF
+:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
+:update
+:quit
 EOF
-cat >>/etc/sysconfig/sshd <<-EOF
+cat >>/etc/sysconfig/sshd <<EOF
 
-	# Decrease connection time by preventing reverse DNS lookups
-	# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
-	#  and man sshd for more information)
-	OPTIONS="-u0"
+# Decrease connection time by preventing reverse DNS lookups
+# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+#  and man sshd for more information)
+OPTIONS="-u0"
 EOF
 
 # Default insecure vagrant key

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -78,6 +78,19 @@ chown -R vagrant:vagrant /home/vagrant/.ssh
 # wrong SELinux context (see "Known Issues" in the CentOS 6 release notes)
 restorecon -vR /home/vagrant/.ssh
 
+# Fix for issue #76, regular users can gain admin privileges via su
+ex -s /etc/pam.d/su <<'EOF'
+/^account\s\+sufficient\s\+pam_succeed_if.so uid = 0 use_uid quiet$/
+:append
+# allow vagrant to use su, but prevent others from becoming root or vagrant
+account		[success=1 default=ignore] \\
+				pam_succeed_if.so user = vagrant use_uid quiet
+account		required	pam_succeed_if.so user notin root:vagrant
+.
+:update
+:quit
+EOF
+
 # Indicate that vagrant6 infra is being used
 echo 'vag' > /etc/yum/vars/infra
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -56,18 +56,18 @@ PERSISTENT_DHCLIENT="yes"
 EOF
 
 # sshd: disable password authentication and DNS checks
-ex -s /etc/ssh/sshd_config <<-EOF
-	:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
-	:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
-	:update
-	:quit
+ex -s /etc/ssh/sshd_config <<EOF
+:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
+:update
+:quit
 EOF
-cat >>/etc/sysconfig/sshd <<-EOF
+cat >>/etc/sysconfig/sshd <<EOF
 
-	# Decrease connection time by preventing reverse DNS lookups
-	# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
-	#  and man sshd for more information)
-	OPTIONS="-u0"
+# Decrease connection time by preventing reverse DNS lookups
+# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+#  and man sshd for more information)
+OPTIONS="-u0"
 EOF
 
 # Default insecure vagrant key


### PR DESCRIPTION
Users `root` and `vagrant` can use `su` without any limitations, while other users can still use `su` as needed, except to become `root` or `vagrant`.

This patch fixes issue #76.