### PR TITLE
Several optimizations for the Vagrant images

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -36,6 +36,34 @@ rsync
 screen
 nfs-utils
 tuned
+# Microcode updates cannot work in a VM
+-microcode_ctl
+# Firmware packages are not needed in a VM
+-aic94xx-firmware
+-atmel-firmware
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
 
 %end
 

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -120,6 +120,10 @@ sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 pushd /etc/dracut.conf.d
 echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
 popd
+# Fix the SELinux context of the new files
+restorecon -f - <<EOF
+/etc/dracut.conf.d/vmware-fusion-drivers.conf
+EOF
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -37,6 +37,30 @@ screen
 nfs-utils
 chrony
 yum-utils
+# Microcode updates cannot work in a VM
+-microcode_ctl
+# Firmware packages are not needed in a VM
+-aic94xx-firmware
+-alsa-firmware
+-alsa-tools-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-iwl7265-firmware
 
 %end
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -66,6 +66,11 @@ yum-utils
 
 %end
 
+# kdump needs to reserve 160MB + 2bits/4kB RAM, and automatic allocation only
+# works on systems with at least 2GB RAM (which excludes most Vagrant boxes)
+%addon com_redhat_kdump --disable
+%end
+
 %post
 
 # sudo

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -61,6 +61,8 @@ yum-utils
 -iwl6050-firmware
 -iwl7260-firmware
 -iwl7265-firmware
+# Don't build rescue initramfs
+-dracut-config-rescue
 
 %end
 


### PR DESCRIPTION
- do not install most firmware packages
- do not install `microcode_ctl`
- do not build a rescue initramfs
- do not load the floppy module on `centos/7`
- disable kdump in `centos/7`