### PR TITLE
Fix SELinux context of /etc/sudoers.d/vagrant

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -135,6 +135,7 @@ echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF
+/etc/sudoers.d/vagrant
 /etc/dracut.conf.d/vmware-fusion-drivers.conf
 EOF
 # Rerun dracut for the installed kernel (not the running kernel):

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -144,6 +144,7 @@ echo 'omit_drivers+=" floppy "' > nofloppy.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF
+/etc/sudoers.d/vagrant
 /etc/dracut.conf.d/vmware-fusion-drivers.conf
 /etc/dracut.conf.d/nofloppy.conf
 EOF


### PR DESCRIPTION
/etc/sudoers.d/vagrant had type etc_runtime_t instead of etc_t
