### PR TITLE
Increase /boot size to 1GiB, the new 7.3 default

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -19,7 +19,7 @@ clearpart --all --drives=vda
 user --name=vagrant --password=vagrant
 
 part biosboot --fstype=biosboot --size=1
-part /boot --fstype xfs --size=500 --ondisk=vda
+part /boot --fstype xfs --size=1024 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536


### PR DESCRIPTION
According to bz1270883, 500MB is still not enough for having three
kernels installed in parallel. The default size of the /boot partition
was increased to 1GiB in RHEL 7.3.

https://bugzilla.redhat.com/show_bug.cgi?id=1270883

Fix for issue #83.