### PR TITLE
Be more flexible when checking package requirements in containerbuild.sh

### DIFF
--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -30,7 +30,7 @@ fi
 PACKAGES=( lorax libvirt virt-install qemu-kvm )
 for Element in "${PACKAGES[@]}"
   do
-    TEST=`rpm -q $Element`
+    TEST=`rpm -q --whatprovides $Element`
     if [ "$?" -gt 0 ]
     then echo "RPM $Element missing"
     exit 1


### PR DESCRIPTION
A requirement might be provided by an RPM with a different name, e.g.
qemu-kvm is also provided by qemu-kvm-ev:

$ rpm -q --provides qemu-kvm-ev
...
qemu-kvm = 10:2.3.0-31.el7.centos_2.21.1
qemu-kvm-ev = 10:2.3.0-31.el7.centos_2.21.1