### PR TITLE
Update centos-7.ks

### DIFF
--- a/docker/centos-7.ks
+++ b/docker/centos-7.ks
@@ -81,8 +81,7 @@ yum clean all
 rm -rf /boot
 rm -rf /etc/firewalld
 
-# Randomize root's password and lock
-dd if=/dev/urandom count=50 | md5sum | passwd --stdin root
+# Lock roots account, keep roots account password-less.
 passwd -l root
 
 #LANG="en_US"


### PR DESCRIPTION
Removing the random password for root, empty feels more logical.
Issue spotted at #32.