### PR TITLE
Remove code that disables requiretty, which is now the default

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -71,7 +71,6 @@ tuned
 
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
 # Fix for https://github.com/CentOS/sig-cloud-instance-build/issues/38
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -76,7 +76,6 @@ yum-utils
 
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
 # Fix for https://github.com/CentOS/sig-cloud-instance-build/issues/38
 cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF


### PR DESCRIPTION
CentOS 7.3 includes sudo-1.8.6p7-21 which disables requiretty by default.

CentOS 6 has not required this since at least 6.8.