### PR TITLE
Update cloud-init settings in generic cloud image

### DIFF
--- a/cloudimg/CentOS-7-x86_64-GenericCloud-201606-r1.ks
+++ b/cloudimg/CentOS-7-x86_64-GenericCloud-201606-r1.ks
@@ -21,7 +21,7 @@ timezone UTC --isUtc
 # Disk
 bootloader --append="console=tty0" --location=mbr --timeout=1 --boot-drive=vda
 zerombr
-clearpart --all --initlabel 
+clearpart --all --initlabel
 part / --fstype="xfs" --ondisk=vda --size=4096 --grow
 
 %post --erroronfail
@@ -170,4 +170,3 @@ yum-utils
 -plymouth
 
 %end
-

--- a/cloudimg/CentOS-7-x86_64-GenericCloud-201606-r1.ks
+++ b/cloudimg/CentOS-7-x86_64-GenericCloud-201606-r1.ks
@@ -124,6 +124,11 @@ mkdir -p /var/cache/yum
 # reorder console entries
 sed -i 's/console=tty0/console=tty0 console=ttyS0,115200n8/' /boot/grub2/grub.cfg
 
+# change cloud-init default settings
+sed -i -e 's/name:\s*fedora/name: centos/' \
+       -e 's/distro:\s*fedora/distro: rhel/' \
+       -e 's/gecos:.*/gecos: Cloud User/' /etc/cloud/cloud.cfg
+
 %end
 
 %packages


### PR DESCRIPTION
This pull request cleans up some blank spaces in the kickstart file; and update cloud-init default settings to make the resulting cloud image look more like CentOS than Fedora.

* 047f3a2 Update cloud-init settings in generic cloud kickstart
* 387023a Remove blank spaces from CentOS-7-x86_64-GenericCloud-201606-r1.ks