### PR TITLE
Use pvscsi as the disk controller in VMware images

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -130,7 +130,7 @@ sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 # Enable VMware PVSCSI support for VMware Fusion guests. This produces
 # a tiny increase in the image and is harmless for other environments.
 pushd /etc/dracut.conf.d
-echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -138,7 +138,7 @@ chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
 # Customize the initramfs
 pushd /etc/dracut.conf.d
 # Enable VMware PVSCSI support for VMware Fusion guests.
-echo 'add_drivers+=" mptspi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
 # There's no floppy controller, but probing for it generates timeouts
 echo 'omit_drivers+=" floppy "' > nofloppy.conf
 popd

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -34,6 +34,7 @@ build_vagrant_image()
     --format=vagrant-libvirt \
     --format=vagrant-virtualbox \
     --format=vagrant-vmware-fusion \
+    --factory-parameter fusion_scsi_controller_type pvscsi \
     --ova-option vagrant_sync_directory=/vagrant \
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\


### PR DESCRIPTION
The default disk controller, LSILogic, needs the mptspi and mptscsih
kernel modules, which were already marked as deprecated in RHEL 6.8 and
7.2. The paravirtualized disk controller, pvscsi, offers better
performance and generates lower load on the host.