### PR TITLE
Also generate images for Hyper-V

### DIFF
--- a/vagrant/centos6-hyperv.ks
+++ b/vagrant/centos6-hyperv.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 
@@ -130,15 +130,13 @@ tuned-adm profile virtual-guest
 # Configure grub to wait just 1 second before booting
 sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 
-# Enable VMware PVSCSI support for VMware Fusion guests. This produces
-# a tiny increase in the image and is harmless for other environments.
 pushd /etc/dracut.conf.d
-echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF
 /etc/sudoers.d/vagrant
-/etc/dracut.conf.d/vmware-fusion-drivers.conf
+/etc/dracut.conf.d/hyperv-drivers.conf
 EOF
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -145,4 +145,9 @@ EOF
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
+
+# Seal for deployment
+rm -rf /etc/ssh/ssh_host_*
+sed -i 's/^HOSTNAME=.*$/HOSTNAME=localhost.localdomain/' /etc/sysconfig/network
+rm -rf /etc/udev/rules.d/70-*
 %end

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -36,6 +36,7 @@ rsync
 screen
 nfs-utils
 tuned
+hyperv-daemons
 # Microcode updates cannot work in a VM
 -microcode_ctl
 # Firmware packages are not needed in a VM
@@ -131,11 +132,13 @@ sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 # a tiny increase in the image and is harmless for other environments.
 pushd /etc/dracut.conf.d
 echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF
 /etc/sudoers.d/vagrant
 /etc/dracut.conf.d/vmware-fusion-drivers.conf
+/etc/dracut.conf.d/hyperv-drivers.conf
 EOF
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos7-hyperv.ks
+++ b/vagrant/centos7-hyperv.ks
@@ -1,74 +1,78 @@
-#repo http://mirror.centos.org/centos/6/os/x86_64/
+#repo http://mirror.centos.org/centos/7/os/x86_64/
 install
 text
 keyboard us
 lang en_US.UTF-8
 skipx
 network --device eth0 --bootproto dhcp
-rootpw vagrant
+rootpw --plaintext vagrant
 firewall --disabled
 authconfig --enableshadow --enablemd5
 selinux --enforcing
 timezone --utc UTC
-services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 
 user --name=vagrant --password=vagrant
 
 part biosboot --fstype=biosboot --size=1
-part /boot --fstype ext4 --size=250 --ondisk=vda
+part /boot --fstype xfs --size=1024 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
 logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
-logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
+logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages
 deltarpm
+bash-completion
 man-pages
 bzip2
 @core
 rsync
 screen
 nfs-utils
-tuned
+chrony
+yum-utils
 hyperv-daemons
 # Microcode updates cannot work in a VM
 -microcode_ctl
 # Firmware packages are not needed in a VM
 -aic94xx-firmware
--atmel-firmware
--bfa-firmware
--ipw2100-firmware
--ipw2200-firmware
+-alsa-firmware
+-alsa-tools-firmware
 -ivtv-firmware
 -iwl100-firmware
 -iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
 -iwl3945-firmware
 -iwl4965-firmware
 -iwl5000-firmware
 -iwl5150-firmware
 -iwl6000-firmware
 -iwl6000g2a-firmware
+-iwl6000g2b-firmware
 -iwl6050-firmware
--libertas-usb8388-firmware
--ql2100-firmware
--ql2200-firmware
--ql23xx-firmware
--ql2400-firmware
--ql2500-firmware
--rt61pci-firmware
--rt73usb-firmware
--xorg-x11-drv-ati-firmware
--zd1211-firmware
+-iwl7260-firmware
+-iwl7265-firmware
+# Don't build rescue initramfs
+-dracut-config-rescue
 # Disable kdump
 -kexec-tools
-
 %end
+
+# kdump needs to reserve 160MB + 2bits/4kB RAM, and automatic allocation only
+# works on systems with at least 2GB RAM (which excludes most Vagrant boxes)
+# CBS doesn't support %addon yet https://bugs.centos.org/view.php?id=12169
+#%addon com_redhat_kdump --disable
+#%end
 
 %post
 
@@ -104,15 +108,12 @@ mkdir -m 0700 -p /home/vagrant/.ssh
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys
 chmod 600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh
-# Workaround for SSH pubkey auth not working, due to .ssh having the
-# wrong SELinux context (see "Known Issues" in the CentOS 6 release notes)
-restorecon -vR /home/vagrant/.ssh
 
 # Fix for issue #76, regular users can gain admin privileges via su
 ex -s /etc/pam.d/su <<'EOF'
+# allow vagrant to use su, but prevent others from becoming root or vagrant
 /^account\s\+sufficient\s\+pam_succeed_if.so uid = 0 use_uid quiet$/
 :append
-# allow vagrant to use su, but prevent others from becoming root or vagrant
 account		[success=1 default=ignore] \\
 				pam_succeed_if.so user = vagrant use_uid quiet
 account		required	pam_succeed_if.so user notin root:vagrant
@@ -121,31 +122,40 @@ account		required	pam_succeed_if.so user notin root:vagrant
 :quit
 EOF
 
-# Indicate that vagrant6 infra is being used
+# systemd should generate a new machine id during the first boot, to
+# avoid having multiple Vagrant instances with the same id in the local
+# network. /etc/machine-id should be empty, but it must exist to prevent
+# boot errors (e.g.  systemd-journald failing to start).
+:>/etc/machine-id
+
 echo 'vag' > /etc/yum/vars/infra
 
-# Configure tuned
-tuned-adm profile virtual-guest
-
 # Configure grub to wait just 1 second before booting
-sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
+sed -i 's/^GRUB_TIMEOUT=[0-9]\+$/GRUB_TIMEOUT=1/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg
 
-# Enable VMware PVSCSI support for VMware Fusion guests. This produces
-# a tiny increase in the image and is harmless for other environments.
+# Blacklist the floppy module to avoid probing timeouts
+echo blacklist floppy > /etc/modprobe.d/nofloppy.conf
+chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
+
+# Customize the initramfs
 pushd /etc/dracut.conf.d
-echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
+# There's no floppy controller, but probing for it generates timeouts
+echo 'omit_drivers+=" floppy "' > nofloppy.conf
 popd
 # Fix the SELinux context of the new files
 restorecon -f - <<EOF
 /etc/sudoers.d/vagrant
-/etc/dracut.conf.d/vmware-fusion-drivers.conf
+/etc/dracut.conf.d/hyperv-drivers.conf
+/etc/dracut.conf.d/nofloppy.conf
 EOF
+
 # Rerun dracut for the installed kernel (not the running kernel):
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
 
 # Seal for deployment
 rm -rf /etc/ssh/ssh_host_*
-sed -i 's/^HOSTNAME=.*$/HOSTNAME=localhost.localdomain/' /etc/sysconfig/network
+hostnamectl set-hostname localhost.localdomain
 rm -rf /etc/udev/rules.d/70-*
 %end

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -37,6 +37,7 @@ screen
 nfs-utils
 chrony
 yum-utils
+hyperv-daemons
 # Microcode updates cannot work in a VM
 -microcode_ctl
 # Firmware packages are not needed in a VM
@@ -139,6 +140,7 @@ chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
 pushd /etc/dracut.conf.d
 # Enable VMware PVSCSI support for VMware Fusion guests.
 echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
 # There's no floppy controller, but probing for it generates timeouts
 echo 'omit_drivers+=" floppy "' > nofloppy.conf
 popd
@@ -146,6 +148,7 @@ popd
 restorecon -f - <<EOF
 /etc/sudoers.d/vagrant
 /etc/dracut.conf.d/vmware-fusion-drivers.conf
+/etc/dracut.conf.d/hyperv-drivers.conf
 /etc/dracut.conf.d/nofloppy.conf
 EOF
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 
@@ -141,7 +141,6 @@ chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
 pushd /etc/dracut.conf.d
 # Enable VMware PVSCSI support for VMware Fusion guests.
 echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
-echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
 # There's no floppy controller, but probing for it generates timeouts
 echo 'omit_drivers+=" floppy "' > nofloppy.conf
 popd
@@ -149,7 +148,6 @@ popd
 restorecon -f - <<EOF
 /etc/sudoers.d/vagrant
 /etc/dracut.conf.d/vmware-fusion-drivers.conf
-/etc/dracut.conf.d/hyperv-drivers.conf
 /etc/dracut.conf.d/nofloppy.conf
 EOF
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -157,4 +157,8 @@ EOF
 KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
 
+# Seal for deployment
+rm -rf /etc/ssh/ssh_host_*
+hostnamectl set-hostname localhost.localdomain
+rm -rf /etc/udev/rules.d/70-*
 %end

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -34,8 +34,22 @@ build_vagrant_image()
     --format=vagrant-libvirt \
     --format=vagrant-virtualbox \
     --format=vagrant-vmware-fusion \
-    --format=vagrant-hyperv \
     --factory-parameter fusion_scsi_controller_type pvscsi \
+    --ova-option vagrant_sync_directory=/vagrant \
+    --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
+    --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\
+    --scratch \
+    ${WAIT:-"--nowait"} \
+    --disk-size=40
+
+  koji -p cbs image-build \
+    centos-${EL_MAJOR} 1  cloudinstance${EL_MAJOR}-common-el${EL_MAJOR} \
+    http://mirror.centos.org/centos/${EL_MAJOR}/os/x86_64/ x86_64 \
+    --release=1 \
+    --distro RHEL-${EL_MAJOR}.0 \
+    --ksver RHEL${EL_MAJOR} \
+    --kickstart=${KS_DIR}/centos${EL_MAJOR}-hyperv.ks \
+    --format=vagrant-hyperv \
     --ova-option vagrant_sync_directory=/vagrant \
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -34,6 +34,7 @@ build_vagrant_image()
     --format=vagrant-libvirt \
     --format=vagrant-virtualbox \
     --format=vagrant-vmware-fusion \
+    --format=vagrant-hyperv \
     --factory-parameter fusion_scsi_controller_type pvscsi \
     --ova-option vagrant_sync_directory=/vagrant \
     --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\


### PR DESCRIPTION
Hyper-V support finally made possible by recent upgrades to CBS; in particular, we are now using qemu-img-ev from the Virt SIG; qemu-img from CentOS generates sparse .vhd files, which expand to the full 40GB size on Windows and generate lots of disk I/O.