### PR TITLE
Disable kdump to conserve memory

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -64,6 +64,8 @@ tuned
 -rt73usb-firmware
 -xorg-x11-drv-ati-firmware
 -zd1211-firmware
+# Disable kdump
+-kexec-tools
 
 %end
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -63,7 +63,8 @@ yum-utils
 -iwl7265-firmware
 # Don't build rescue initramfs
 -dracut-config-rescue
-
+# Disable kdump
+-kexec-tools
 %end
 
 # kdump needs to reserve 160MB + 2bits/4kB RAM, and automatic allocation only


### PR DESCRIPTION
kdump needs to reserve 160MB + 2bits/4kB RAM, and automatic allocation
only works on systems with at least 2GB RAM (which excludes most Vagrant
boxes)