### PR TITLE
docker: change dependencies to anaconda-tui

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,9 +10,8 @@ This method does NOT work for CentOS-5 base containers.
 
 The following packages and dependencies are needed:
 
- * libguestfs-tools-c
  * lorax
- * virt-install
+ * anaconda-tui
 
 
 ## Build

--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -26,7 +26,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 # Test for package requirements
-PACKAGES=( anaconda lorax )
+PACKAGES=( anaconda-tui lorax )
 for Element in "${PACKAGES[@]}"
   do
     TEST=`rpm -q --whatprovides $Element`


### PR DESCRIPTION
Anaconda pulls in all sorts of gtk modules, mesa and X libraries while anaconda-tui is prefectly sufficient and does not pull in all these extra dependencies.