### PR TITLE
Reduce image size by not installing docs

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -26,7 +26,7 @@ logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow 
 logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
-%packages
+%packages --excludedocs --instLangs=en
 deltarpm
 bash-completion
 man-pages


### PR DESCRIPTION
Anaconda supports omitting the docs files when installing packages. This
reduces the image size of centos/7 from 386MB to 320MB, making spinning
up a new Vagrant box faster.

It is still possible to reinstall a package with the documentation, if a
user wants that. The "--excludedocs" option of Kickstart is already used
by our Docker images; it's only to my chronic lack of time that it took
so long for the Vagrant images to use that, too.