### PR TITLE
Exclude documentation to reduce centos/6 image size

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -27,7 +27,7 @@ logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow 
 logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
-%packages
+%packages --excludedocs --instLangs=en
 deltarpm
 man-pages
 bzip2


### PR DESCRIPTION
This commit mirrors the last change to centos/7. The --excludedocs
and --instLangs options are honored by CentOS Linux 6, even if they
aren't mentioned by the official RHEL6 installation guide.