### PR TITLE
raise maxsize of swap to a more suitable value

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -22,7 +22,7 @@ part biosboot --fstype=biosboot --size=1
 part /boot --fstype xfs --size=1024 --ondisk=vda
 part pv.2 --size=1 --grow --ondisk=vda
 volgroup VolGroup00 --pesize=32768 pv.2
-logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
+logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=2048
 logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 


### PR DESCRIPTION
currently oracle database needs a 2g swap size.
this changes the ks to support a swap size of 2g