### PR TITLE
Use a single partition for the Vagrant images

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,18 +13,13 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
+part / --fstype=ext4 --asprimary --size=1024 --grow --ondisk=vda
 
 user --name=vagrant --password=vagrant
 
-part biosboot --fstype=biosboot --size=1
-part /boot --fstype ext4 --size=250 --ondisk=vda
-part pv.2 --size=1 --grow --ondisk=vda
-volgroup VolGroup00 --pesize=32768 pv.2
-logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
-logvol / --fstype ext4 --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -30,6 +30,7 @@ bzip2
 rsync
 screen
 nfs-utils
+cifs-utils
 tuned
 hyperv-daemons
 # Microcode updates cannot work in a VM

--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 part / --fstype=ext4 --asprimary --size=1024 --grow --ondisk=vda
@@ -121,9 +121,6 @@ echo 'vag' > /etc/yum/vars/infra
 
 # Configure tuned
 tuned-adm profile virtual-guest
-
-# Configure grub to wait just 1 second before booting
-sed -i 's/^timeout=[0-9]\+$/timeout=1/' /boot/grub/grub.conf
 
 # Enable VMware PVSCSI support for VMware Fusion guests. This produces
 # a tiny increase in the image and is harmless for other environments.

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -24,15 +24,16 @@ reboot
 %packages --excludedocs --instLangs=en
 deltarpm
 bash-completion
-man-pages
 bzip2
-@core
 rsync
-screen
 nfs-utils
 chrony
 yum-utils
 hyperv-daemons
+-e2fsprogs
+-btrfs-progs
+# Vagrant boxes aren't normally visible, no need for Plymouth
+-plymouth
 # Microcode updates cannot work in a VM
 -microcode_ctl
 # Firmware packages are not needed in a VM
@@ -57,6 +58,7 @@ hyperv-daemons
 -iwl6050-firmware
 -iwl7260-firmware
 -iwl7265-firmware
+-linux-firmware
 # Don't build rescue initramfs
 -dracut-config-rescue
 # Disable kdump

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -28,6 +28,7 @@ man-pages
 bzip2
 rsync
 nfs-utils
+cifs-utils
 chrony
 yum-utils
 hyperv-daemons

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -26,7 +26,7 @@ logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow 
 logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
-%packages
+%packages --excludedocs --instLangs=en
 deltarpm
 bash-completion
 man-pages

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
 part / --fstype=xfs --asprimary --size=1024 --grow --ondisk=vda
@@ -124,9 +124,6 @@ EOF
 :>/etc/machine-id
 
 echo 'vag' > /etc/yum/vars/infra
-
-# Configure grub to wait just 1 second before booting
-sed -i 's/^GRUB_TIMEOUT=[0-9]\+$/GRUB_TIMEOUT=1/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg
 
 # Blacklist the floppy module to avoid probing timeouts
 echo blacklist floppy > /etc/modprobe.d/nofloppy.conf

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -15,7 +15,7 @@ timezone --utc UTC
 bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
 zerombr
 clearpart --all --drives=vda
-part / --fstype=xfs --asprimary --size=1024 --grow --ondisk=vda
+part / --fstype=ext4 --asprimary --size=1024 --grow --ondisk=vda
 
 user --name=vagrant --password=vagrant
 
@@ -75,9 +75,8 @@ hyperv-daemons
 
 %post
 
-# configure swap to a file - we can't use fallocate on XFS though
-# (see https://bugzilla.redhat.com/show_bug.cgi?id=1129205#c3)
-dd if=/dev/zero of=/swapfile bs=1M count=2048
+# configure swap to a file
+fallocate -l 2G /swapfile
 chmod 600 /swapfile
 mkswap /swapfile
 echo "/swapfile none swap defaults 0 0" >> /etc/fstab

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,18 +12,13 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
 zerombr
 clearpart --all --drives=vda
+part / --fstype=xfs --asprimary --size=1024 --grow --ondisk=vda
 
 user --name=vagrant --password=vagrant
 
-part biosboot --fstype=biosboot --size=1
-part /boot --fstype xfs --size=1024 --ondisk=vda
-part pv.2 --size=1 --grow --ondisk=vda
-volgroup VolGroup00 --pesize=32768 pv.2
-logvol swap --fstype swap --name=LogVol01 --vgname=VolGroup00 --size=768 --grow --maxsize=1536
-logvol / --fstype xfs --name=LogVol00 --vgname=VolGroup00 --size=1024 --grow
 reboot
 
 %packages --excludedocs --instLangs=en

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -21,9 +21,10 @@ user --name=vagrant --password=vagrant
 
 reboot
 
-%packages --excludedocs --instLangs=en
+%packages --instLangs=en
 deltarpm
 bash-completion
+man-pages
 bzip2
 rsync
 nfs-utils


### PR DESCRIPTION
Having a single root partition, without swap or two boot partitions, provides more flexibility for our users (most of them don't need swap, but should set the VM to at least 1024MB RAM). Resizing the disk also becomes simpler than when we were using LVM.

Alternative to PR #113.