### PR TITLE
Fix typo, actually preventing removal of the nologin file.

### DIFF
--- a/docker/centos-7arm64.ks
+++ b/docker/centos-7arm64.ks
@@ -121,7 +121,7 @@ rm -rf /usr/lib/udev/hwdb.d/*
 umount /run
 systemd-tmpfiles --create --boot
 # Make sure login works
-m /var/run/nologin
+rm /var/run/nologin
 
 
 #Generate installtime file record


### PR DESCRIPTION
The current image contains a /run/nologin file, preventing login.