### PR TITLE
Set the default IO scheduler to noop

### DIFF
--- a/vagrant/centos6.ks
+++ b/vagrant/centos6.ks
@@ -13,7 +13,7 @@ timezone --utc UTC
 services --enabled ntpd,tuned
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
 zerombr
 clearpart --all --drives=vda
 

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -12,7 +12,7 @@ selinux --enforcing
 timezone --utc UTC
 # The biosdevname and ifnames options ensure we get "eth0" as our interface
 # even in environments like virtualbox that emulate a real NW card
-bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
 zerombr
 clearpart --all --drives=vda
 


### PR DESCRIPTION
The best IO scheduler for a VM is noop, not the default cfq.  We have to
send the disk sectors to be written or read as fast as possible to the
host OS, which is the only one able to optimize and reorder the disk
operations considering the needs of all hosted VMs and other
applications that might be running.

The RedHat documentation also recommends noop for guest VMs, unless they
use dedicated raw partitions (not the case for Vagrant images).