### PR TITLE
Add architecture to basesearch for i386 image

### DIFF
--- a/docker/centos-7i386.ks
+++ b/docker/centos-7i386.ks
@@ -93,6 +93,7 @@ awk '(NF==0&&!done){print "override_install_langs=en_US.utf8\ntsflags=nodocs";do
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
+echo -e 'i386\n' > /etc/yum/vars/basesearch
 
 
 ##Setup locale properly


### PR DESCRIPTION
This was a leftover from #108.

Problem:

```sh
docker run -it i386/centos

# in the container
yum update

...
failure: repodata/repomd.xml from base: [Errno 256] No more mirrors to try.
http://mirror.centos.org/altarch/7/os/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
...
```

Workaround: `echo -e 'i386\n' > /etc/yum/vars/basesearch   &&  yum update`.

Fixes #119