### PR TITLE
Docker image: remove qemu-guest-agent package

### DIFF
--- a/docker/centos-7.ks
+++ b/docker/centos-7.ks
@@ -59,7 +59,6 @@ passwd
 yum-utils
 yum-plugin-ovl
 
-
 %end
 
 %post --log=/anaconda-post.log
@@ -75,7 +74,8 @@ yum -y remove bind-libs bind-libs-lite dhclient dhcp-common dhcp-libs \
   grubby initscripts iproute iptables kexec-tools libcroco libgomp \
   libmnl libnetfilter_conntrack libnfnetlink libselinux-python lzo \
   libunistring os-prober python-decorator python-slip python-slip-dbus \
-  snappy sysvinit-tools which linux-firmware GeoIP firewalld-filesystem
+  snappy sysvinit-tools which linux-firmware GeoIP firewalld-filesystem \
+  qemu-guest-agent
 
 yum clean all
 


### PR DESCRIPTION
Using the `--novirt` parameter (#104) the package `qemu-guest-agent` is installed within the Docker image, but it is not required and could be removed.