### PR TITLE
Set basearch to i386 for i386 images

### DIFF
--- a/docker/centos-6i386.ks
+++ b/docker/centos-6i386.ks
@@ -81,6 +81,7 @@ awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
+echo -e 'i386\n' > /etc/yum/vars/basearch
 
 rm -f /usr/lib/locale/locale-archive
 

--- a/docker/centos-7i386.ks
+++ b/docker/centos-7i386.ks
@@ -93,7 +93,7 @@ awk '(NF==0&&!done){print "override_install_langs=en_US.utf8\ntsflags=nodocs";do
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
-echo -e 'i386\n' > /etc/yum/vars/basesearch
+echo -e 'i386\n' > /etc/yum/vars/basearch
 
 
 ##Setup locale properly


### PR DESCRIPTION
Fix https://github.com/CentOS/sig-cloud-instance-images/issues/94
Fix https://github.com/CentOS/sig-cloud-instance-images/issues/123