### PR TITLE
force basearch

### DIFF
--- a/docker/centos-6i386.ks
+++ b/docker/centos-6i386.ks
@@ -81,6 +81,7 @@ awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
+echo 'i386' > /etc/yum/vars/basearch
 
 rm -f /usr/lib/locale/locale-archive
 


### PR DESCRIPTION
I did not test this actual patch; I did test `yum install` in the following context:
```
FROM i386/centos:6 as dist-base
RUN echo 'i386' > /etc/yum/vars/basearch
```