### PR TITLE
Fix typo basesearch->basearch

### DIFF
--- a/docker/centos-7-i386.ks
+++ b/docker/centos-7-i386.ks
@@ -93,7 +93,7 @@ awk '(NF==0&&!done){print "override_install_langs=en_US.utf8\ntsflags=nodocs";do
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra
-echo -e 'i386\n' > /etc/yum/vars/basesearch
+echo -e 'i386\n' > /etc/yum/vars/basearch
 
 
 ##Setup locale properly


### PR DESCRIPTION
This extra `se` was causing a 404 when trying out `yum update` on fresh install.
