### PR TITLE
Back to xfs

### DIFF
--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -34,8 +34,6 @@ chrony
 yum-utils
 hyperv-daemons
 open-vm-tools
--e2fsprogs
--btrfs-progs
 # Vagrant boxes aren't normally visible, no need for Plymouth
 -plymouth
 # Microcode updates cannot work in a VM

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -74,9 +74,8 @@ open-vm-tools
 #%end
 
 %post
-
-# configure swap to a file
-fallocate -l 2G /swapfile
+# configure swap to a file (fallocate doesn't work with c7 xfs)
+dd if=/dev/zero of=/swapfile bs=1M count=2048
 chmod 600 /swapfile
 mkswap /swapfile
 echo "/swapfile none swap defaults 0 0" >> /etc/fstab

--- a/vagrant/centos7.ks
+++ b/vagrant/centos7.ks
@@ -16,7 +16,7 @@ services --enabled=vmtoolsd
 bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
 zerombr
 clearpart --all --drives=vda
-part / --fstype=ext4 --asprimary --size=1024 --grow --ondisk=vda
+part / --fstype=xfs --asprimary --size=1024 --grow --ondisk=vda
 
 user --name=vagrant --password=vagrant
 


### PR DESCRIPTION
CentOS 7.6 appears to produce valid Vagrant images when used on both the Image Factory builder and as the netinst installer of the guest. Whatever the issue was with XFS in 7.5, it probably was in qemu-kvm, because trying to create 7.6 Vagrant images on a 7.5 builder still produces filesystem corruption.

We should switch back to XFS because:
* libaio requires XFS
* docker only supports XFS for the overlay filesystem