### PR TITLE
Fix the format of org.label-schema.build-date

### DIFF
--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -63,6 +63,7 @@ mv /var/tmp/"$KSNAME"-docker.tar.xz $BUILDROOT/docker/
 
 # Create a Dockerfile to go along with the rootfs.
 
+BUILDDATE_RFC3339="$(date -d $BUILDDATE --rfc-3339=date)"
 cat << EOF > $BUILDROOT/docker/Dockerfile
 FROM scratch
 ADD $KSNAME-docker.tar.xz /
@@ -71,7 +72,7 @@ LABEL org.label-schema.schema-version="1.0" \\
     org.label-schema.name="CentOS Base Image" \\
     org.label-schema.vendor="CentOS" \\
     org.label-schema.license="GPLv2" \\
-    org.label-schema.build-date="$BUILDDATE"
+    org.label-schema.build-date="$BUILDDATE_RFC3339"
 
 CMD ["/bin/bash"]
 EOF


### PR DESCRIPTION
The [convention draft](http://label-schema.org/rc1/) clearly states that `org.label-schema.build-date` should be in  [RFC 3339](https://tools.ietf.org/html/rfc3339) format:

> This label contains the Date/Time the image was built. The value SHOULD be formatted according to RFC 3339.

Addresses https://github.com/CentOS/sig-cloud-instance-images/issues/100#issuecomment-468344953