### PR TITLE
port fix for yum override_install_langs from 2892c17 for aarch64

### DIFF
--- a/docker/centos-7-aarch64.ks
+++ b/docker/centos-7-aarch64.ks
@@ -94,7 +94,7 @@ passwd -l root
 #LANG="en_US"
 #echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
 
-awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=1}{print}' \
+awk '(NF==0&&!done){print "override_install_langs=en_US.utf8\ntsflags=nodocs";done=1}{print}' \
     < /etc/yum.conf > /etc/yum.conf.new
 mv /etc/yum.conf.new /etc/yum.conf
 echo 'container' > /etc/yum/vars/infra


### PR DESCRIPTION
Adds the changes from https://github.com/CentOS/sig-cloud-instance-build/commit/2892c17fa8a520e58c3f42cd56587863fe675670 to the `aarch64` image.

Fixes:
```sh
> docker run --rm arm64v8/centos:7 sh -c \
>     'yum reinstall -q -y glibc-common >/dev/null 2>&1 && LC_ALL=en_US.UTF-8 sh -c :'
/usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```