### PR TITLE
 Use new OCI labels instead of label-schema ones

### DIFF
--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -63,7 +63,7 @@ mv /var/tmp/"$KSNAME"-docker.tar.xz $BUILDROOT/docker/
 
 # Create a Dockerfile to go along with the rootfs.
 
-BUILDDATE_RFC3339="$(date -d $BUILDDATE --rfc-3339=date)"
+BUILDDATE_RFC3339="$(date -d $BUILDDATE --rfc-3339=seconds)"
 cat << EOF > $BUILDROOT/docker/Dockerfile
 FROM scratch
 ADD $KSNAME-docker.tar.xz /

--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -68,11 +68,11 @@ cat << EOF > $BUILDROOT/docker/Dockerfile
 FROM scratch
 ADD $KSNAME-docker.tar.xz /
 
-LABEL org.label-schema.schema-version="1.0" \\
-    org.label-schema.name="CentOS Base Image" \\
-    org.label-schema.vendor="CentOS" \\
-    org.label-schema.license="GPLv2" \\
-    org.label-schema.build-date="$BUILDDATE_RFC3339"
+LABEL \\
+    org.opencontainers.image.title="CentOS Base Image" \\
+    org.opencontainers.image.vendor="CentOS" \\
+    org.opencontainers.image.licenses="GPL-2.0-only" \\
+    org.opencontainers.image.created="$BUILDDATE_RFC3339"
 
 CMD ["/bin/bash"]
 EOF

--- a/docker/containerbuild.sh
+++ b/docker/containerbuild.sh
@@ -69,6 +69,11 @@ FROM scratch
 ADD $KSNAME-docker.tar.xz /
 
 LABEL \\
+    org.label-schema.schema-version="1.0" \\
+    org.label-schema.name="CentOS Base Image" \\
+    org.label-schema.vendor="CentOS" \\
+    org.label-schema.license="GPLv2" \\
+    org.label-schema.build-date="$BUILDDATE" \\
     org.opencontainers.image.title="CentOS Base Image" \\
     org.opencontainers.image.vendor="CentOS" \\
     org.opencontainers.image.licenses="GPL-2.0-only" \\


### PR DESCRIPTION
Contains the work in https://github.com/CentOS/sig-cloud-instance-build/pull/151

Addresses https://github.com/CentOS/sig-cloud-instance-build/pull/151#issuecomment-495359556, though they had the smart suggestion of adding both sets of labels for the time being, until the OCI ones mature.

Partially addresses https://github.com/CentOS/sig-cloud-instance-images/issues/100 too