### PR TITLE
vagrant: Add CentOS 8 box

### DIFF
--- a/vagrant/centos8.ks
+++ b/vagrant/centos8.ks
@@ -1,0 +1,147 @@
+#url --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock
+#repo --name=AppStream --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock
+install
+text
+keyboard us
+lang en_US.UTF-8
+skipx
+network --bootproto dhcp
+rootpw --plaintext vagrant
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc UTC
+services --enabled=vmtoolsd,NetworkManager,sshd
+# The biosdevname and ifnames options ensure we get "eth0" as our interface
+# even in environments like virtualbox that emulate a real NW card
+bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
+zerombr
+clearpart --all --drives=vda
+part / --fstype=xfs --asprimary --size=1024 --grow --ondisk=vda
+
+user --name=vagrant --password=vagrant
+
+reboot
+
+%packages --instLangs=en
+bash-completion
+man-pages
+bzip2
+rsync
+nfs-utils
+cifs-utils
+chrony
+yum-utils
+hyperv-daemons
+open-vm-tools
+# Vagrant boxes aren't normally visible, no need for Plymouth
+-plymouth
+# Microcode updates cannot work in a VM
+-microcode_ctl
+# Firmware packages are not needed in a VM
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-libertas-usb8388-firmware
+#-linux-firmware # Required by kernel-core, can't remove
+# Don't build rescue initramfs
+-dracut-config-rescue
+# Disable kdump
+# -kexec-tools
+%end
+
+%post
+# configure swap to a file (fallocate doesn't work with c7 xfs)
+dd if=/dev/zero of=/swapfile bs=1M count=2048
+chmod 600 /swapfile
+mkswap /swapfile
+echo "/swapfile none swap defaults 0 0" >> /etc/fstab
+
+# sudo
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# sshd: disable password authentication and DNS checks
+ex -s /etc/ssh/sshd_config <<EOF
+:%substitute/^\(PasswordAuthentication\) yes$/\1 no/
+:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
+:update
+:quit
+EOF
+cat >>/etc/sysconfig/sshd <<EOF
+
+# Decrease connection time by preventing reverse DNS lookups
+# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+#  and man sshd for more information)
+OPTIONS="-u0"
+EOF
+
+# Default insecure vagrant key
+mkdir -m 0700 -p /home/vagrant/.ssh
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# Fix for issue #76, regular users can gain admin privileges via su
+ex -s /etc/pam.d/su <<'EOF'
+# allow vagrant to use su, but prevent others from becoming root or vagrant
+/^account\s\+sufficient\s\+pam_succeed_if.so uid = 0 use_uid quiet$/
+:append
+account		[success=1 default=ignore] \\
+				pam_succeed_if.so user = vagrant use_uid quiet
+account		required	pam_succeed_if.so user notin root:vagrant
+.
+:update
+:quit
+EOF
+
+# systemd should generate a new machine id during the first boot, to
+# avoid having multiple Vagrant instances with the same id in the local
+# network. /etc/machine-id should be empty, but it must exist to prevent
+# boot errors (e.g.  systemd-journald failing to start).
+:>/etc/machine-id
+
+echo 'vag' > /etc/yum/vars/infra
+
+# Blacklist the floppy module to avoid probing timeouts
+echo blacklist floppy > /etc/modprobe.d/nofloppy.conf
+chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
+
+# Customize the initramfs
+pushd /etc/dracut.conf.d
+# Enable VMware PVSCSI support for VMware Fusion guests.
+echo 'add_drivers+=" vmw_pvscsi "' > vmware-fusion-drivers.conf
+echo 'add_drivers+=" hv_netvsc hv_storvsc hv_utils hv_vmbus hid-hyperv "' > hyperv-drivers.conf
+# There's no floppy controller, but probing for it generates timeouts
+echo 'omit_drivers+=" floppy "' > nofloppy.conf
+popd
+# Fix the SELinux context of the new files
+restorecon -f - <<EOF
+/etc/sudoers.d/vagrant
+/etc/dracut.conf.d/vmware-fusion-drivers.conf
+/etc/dracut.conf.d/hyperv-drivers.conf
+/etc/dracut.conf.d/nofloppy.conf
+EOF
+
+# Rerun dracut for the installed kernel (not the running kernel):
+KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
+dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
+
+# Seal for deployment
+rm -rf /etc/ssh/ssh_host_*
+hostnamectl set-hostname localhost.localdomain
+rm -rf /etc/udev/rules.d/70-*
+%end

--- a/vagrant/do_vagrant_cbs.sh
+++ b/vagrant/do_vagrant_cbs.sh
@@ -9,7 +9,8 @@ usage: $(basename $0) <argument>
   where <argument> is one of:
     6   -- build Vagrant images for CentOS 6
     7   -- build Vagrant images for CentOS 7
-    all -- build Vagrant images for both CentOS 6 and 7
+    8   -- build Vagrant images for CentOS 8
+    all -- build Vagrant images for both CentOS 6, 7 and 8
 EOF
   exit 1
 }
@@ -24,24 +25,45 @@ build_vagrant_image()
   if [ ! -t 1 ]; then WAIT="--wait"; fi
 
   EL_MAJOR=$1
-  koji -p cbs image-build \
-    centos-${EL_MAJOR} 1  cloudinstance${EL_MAJOR}-common-el${EL_MAJOR} \
-    http://mirror.centos.org/centos/${EL_MAJOR}/os/x86_64/ x86_64 \
-    --release=1 \
-    --distro RHEL-${EL_MAJOR}.0 \
-    --ksver RHEL${EL_MAJOR} \
-    --kickstart=${KS_DIR}/centos${EL_MAJOR}.ks \
-    --format=vagrant-libvirt \
-    --format=vagrant-virtualbox \
-    --format=vagrant-vmware-fusion \
-    --format=vagrant-hyperv \
-    --factory-parameter fusion_scsi_controller_type pvscsi \
-    --ova-option vagrant_sync_directory=/vagrant \
-    --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
-    --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\
-    --scratch \
-    ${WAIT:-"--nowait"} \
-    --disk-size=40
+  if [ "${EL_MAJOR}" -eq 8 ]; then
+    koji -p cbs image-build \
+      centos-${EL_MAJOR} 1  cloudinstance${EL_MAJOR}-common-el${EL_MAJOR} \
+      http://mirror.centos.org/centos/${EL_MAJOR}/BaseOS/x86_64/ x86_64 \
+      --release=1 \
+      --distro RHEL-${EL_MAJOR}.0 \
+      --ksver RHEL${EL_MAJOR} \
+      --kickstart=${KS_DIR}/centos${EL_MAJOR}.ks \
+      --format=vagrant-libvirt \
+      --format=vagrant-virtualbox \
+      --format=vagrant-vmware-fusion \
+      --format=vagrant-hyperv \
+      --factory-parameter fusion_scsi_controller_type pvscsi \
+      --ova-option vagrant_sync_directory=/vagrant \
+      --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/os/\
+      --repo http://mirror.centos.org/centos/${EL_MAJOR}/AppStream/x86_64/os/\
+      --scratch \
+      ${WAIT:-"--nowait"} \
+      --disk-size=40
+  else
+    koji -p cbs image-build \
+      centos-${EL_MAJOR} 1  cloudinstance${EL_MAJOR}-common-el${EL_MAJOR} \
+      http://mirror.centos.org/centos/${EL_MAJOR}/os/x86_64/ x86_64 \
+      --release=1 \
+      --distro RHEL-${EL_MAJOR}.0 \
+      --ksver RHEL${EL_MAJOR} \
+      --kickstart=${KS_DIR}/centos${EL_MAJOR}.ks \
+      --format=vagrant-libvirt \
+      --format=vagrant-virtualbox \
+      --format=vagrant-vmware-fusion \
+      --format=vagrant-hyperv \
+      --factory-parameter fusion_scsi_controller_type pvscsi \
+      --ova-option vagrant_sync_directory=/vagrant \
+      --repo http://mirror.centos.org/centos/${EL_MAJOR}/extras/x86_64/\
+      --repo http://mirror.centos.org/centos/${EL_MAJOR}/updates/x86_64/\
+      --scratch \
+      ${WAIT:-"--nowait"} \
+      --disk-size=40
+  fi
 }
 
 
@@ -56,9 +78,13 @@ case $1 in
   7)
     build_vagrant_image 7
     ;;
+  8)
+    build_vagrant_image 8
+    ;;
   all)
     build_vagrant_image 6
     build_vagrant_image 7
+    build_vagrant_image 8
     ;;
   *)
     usage


### PR DESCRIPTION
Some notes for anyone doing review of this:
* The kickstart file was based on the centos 7 file
* `AppStream` repository is required because of the VM packages (`hyperv-daemons`, `open-vm-tools`)

edit:
Box created with the kickstart file from this PR (created with [Packer](https://www.packer.io/))
https://app.vagrantup.com/rudineirk/boxes/centos8